### PR TITLE
feat: proposed API for serial and I2C

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-graft examples/*
+graft examples

--- a/README.md
+++ b/README.md
@@ -86,15 +86,15 @@ pip3 install -e .
 ## Publish a new version
 Install build deps: `pip3 install build twine`.
 
-Update the version number at `__init__.py` and `setup.cfg`.
+Update the version number at `__init__.py`.
 
 ```bash
 # build the new version
 python3 -m build
 
 # deploy
-twine upload -r testpypi dist/*.whl # to https://test.pypi.org/
-twine upload -r dist/*.whl # to https://pypi.org/
+VERSION=$(grep -r "__version__" caninos_sdk/__init__.py | sed -E 's/.* = "(.*)"/\1/g')
+twine upload dist/caninos_sdk-$VERSION-py3-none-any.whl  --config-file ${HOME}/.pypirc
 ```
 
 

--- a/caninos_sdk/__init__.py
+++ b/caninos_sdk/__init__.py
@@ -6,7 +6,7 @@ logging.basicConfig(
     datefmt="[%Y-%m-%d,%H:%M:%S]",
 )
 
-__version__ = "0.2.6"
+__version__ = "0.2.9"
 
 from caninos_sdk.labrador import Labrador
 from caninos_sdk.pin import Pin

--- a/caninos_sdk/i2c.py
+++ b/caninos_sdk/i2c.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass, field
 from caninos_sdk.pwm import PWM
 import logging, platform, glob
 
+
+# XXX: module under development
 # instalar essa biblioteca: https://github.com/amaork/libi2c
 
 

--- a/caninos_sdk/serial.py
+++ b/caninos_sdk/serial.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass, field
 from caninos_sdk.pwm import PWM
 import logging, platform, serial, glob
 
+# XXX: module under development
+
 
 @dataclass
 class Serial:

--- a/examples/_i2c_arduino.py
+++ b/examples/_i2c_arduino.py
@@ -1,5 +1,7 @@
 import caninos_sdk as k9
 
+# XXX: module under development
+
 labrador = k9.Labrador()
 labrador.i2c.enable(port="/dev/i2c-2", address=0x4, alias="arduino_i2c")
 

--- a/examples/_serial_arduino.py
+++ b/examples/_serial_arduino.py
@@ -1,6 +1,8 @@
 import caninos_sdk as k9
 import time
 
+# XXX: module under development
+
 labrador = k9.Labrador()
 labrador.serial.enable(port="/dev/ttyS0", baudrate=9600, alias="arduino_uart")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,11 +3,15 @@ name = caninos_sdk
 version = attr: caninos_sdk.__version__
 long_description = file: README.md
 long_description_content_type = text/markdown
-include_package_data = True
 
 [options]
 packages = find:
+include_package_data = True
 install_requires =
-    gpiod
     typer
     rich
+    gpiod
+    pyserial
+
+[options.extras_require]
+# put pyserial, cv2 here


### PR DESCRIPTION
This is a placeholder pull request to analyse the serial and i2c API in the caninos sdk.

The implementation is to use wrappers of [libi2c](https://github.com/amaork/libi2c) and [pyserial](https://pypi.org/project/pyserial/).