### PR TITLE
bug fix: when pwm is not running, gpio needs to be low

### DIFF
--- a/caninos_sdk/pwm.py
+++ b/caninos_sdk/pwm.py
@@ -42,3 +42,4 @@ class PWM:
                     self.gpio.high()
                     state = True
                     start = timeit.default_timer()
+        self.gpio.low()


### PR DESCRIPTION
When pwm.stop() was used, there was a possibility that pwm could be stopped when gpio level was high.
